### PR TITLE
GitHub Authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.config-*
 .DS_Store
 node_modules
 .serverless

--- a/README.md
+++ b/README.md
@@ -2,19 +2,43 @@
 #### Serverless private npm registry, proxy and cache.
 
 ### Overview
-Yith is a simple npm registry to allow companies that wish to keep their intellectual property.  It allows sharing of npm modules within a company but additionally allows access to all of the modules on npm.
+Yith is a simple npm registry to allow companies that wish to
+keep their intellectual property.  It allows sharing of npm modules
+within a company but additionally allows access to all of the
+modules on npm.  It replaces npm authentication to be via github / github
+enterprise.
 
 It is compatiable with the latest version of the `npm` cli.
 
+#### Setup Environment Config
+You will need to ensure you have setup the relevant config for a GitHub
+app and endpoint within a file name called `.config-{stage}`.  Replacing
+`{stage}` with the relevant stage you are building (default is dev, e.g. `.config-dev`).
+
+``` js
+module.exports = {
+  registry: 'https://registry.npmjs.org/',
+  github: {
+    endpoint: {
+      protocol: 'https',
+      host: 'github.com',
+      pathPrefix: '/api/v3'
+    },
+    client_id: 'app_client_id',
+    secret: 'app_secret'
+  }
+}
+```
+
 ### Getting Started
-1. Ensure you have administrator credentials set for your AWS account in `~/.aws/credentials`
+1. Ensure you have elevated credentials set for your AWS account in `~/.aws/credentials`
 2. `npm i`
 3. `npm run build`
 4. `npm set registry <url>` - url being the one shown in the terminal after deployment completes, such as:
 `https://abcd12345.execute-api.eu-west-1.amazonaws.com/dev/registry/`
 
 #### Supported Features
-* `npm login` - Proxies through to real npm
+* `npm login` - via github / github enterprise (if 2FA enabled format username for npm login via cli as `username.otp` e.g. `craftship.123456`)
 * `npm publish` - Stores all packages within S3 (Never publishes to real npm)
 * `npm install` - Looks in S3 first, if it does not exist grabs from real npm
 * `npm install@version`- Looks in S3 first, if it does not exist grabs from real npm
@@ -33,7 +57,7 @@ It is compatiable with the latest version of the `npm` cli.
 * Statistics of package downloads and usage information
 
 ##### security
-* Add support for single sign on via github / github enterprise
+* ~~Add support for single sign on via github / github enterprise~~
 * Show any security vulnerabilities of dependencies for packages
 * Show any out dated depedencies for packages
 

--- a/env.js
+++ b/env.js
@@ -1,0 +1,4 @@
+module.exports = function (context) {
+  const stage = context.functionName.split('-')[1]
+  return require(`.config-${stage}`)
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^3.4.1",
+    "github": "^3.0.0",
     "node-fetch": "^1.6.0"
   },
   "devDependencies": {

--- a/serverless.yml
+++ b/serverless.yml
@@ -4,6 +4,7 @@ provider:
   name: aws
   runtime: nodejs4.3
   stage: dev
+  registry: https://registry.npmjs.org/
   region: eu-west-1
   iamRoleStatements:
     - Effect: "Allow"
@@ -14,13 +15,18 @@ provider:
         - "logs:CreateLogGroup"
         - "logs:CreateLogStream"
         - "logs:PutLogEvents"
-      Resource: "arn:aws:s3:::${self:service}*"
+        - "apigateway:POST"
+      Resource:
+        - "arn:aws:s3:::${self:service}*"
+        - "arn:aws:apigateway:*"
 
 package:
   exclude:
-    - ./src
+    - src
 
 functions:
+  githubAuthorizer:
+    handler: lib/authorizer/index.handler
   packageGet:
     handler: lib/package/get/index.handler
     events:
@@ -29,16 +35,30 @@ functions:
           method: get
           request:
             template:
-              application/json: '{ "id": "$input.params(''id'')", "registry": "https://registry.npmjs.org/", "bucket": "${self:service}-${opt:stage}", "region": "eu-west-1" }'
+              application/json: >
+                {
+                  "id": "$input.params('id')",
+                  "registry": "${self:provider.registry}",
+                  "bucket": "${self:service}-${opt:stage}",
+                  "region": "${self:provider.region}"
+                }
   packagePut:
     handler: lib/package/put/index.handler
     events:
       - http:
           path: "registry/{id}"
           method: put
+          authorizer: githubAuthorizer
           request:
             template:
-              application/json: '{ "id": "$input.params(''id'')", "body": "$util.escapeJavaScript($input.json(''$''))", "registry": "https://registry.npmjs.org/", "bucket": "${self:service}-${opt:stage}", "region": "eu-west-1" }'
+              application/json: >
+                {
+                  "id": "$input.params('id')",
+                  "body": "$util.escapeJavaScript($input.json('$'))",
+                  "registry": "${self:provider.registry}",
+                  "bucket": "${self:service}-${opt:stage}",
+                  "region": "${self:provider.region}"
+                }
   userPut:
     handler: lib/user/put/index.handler
     events:
@@ -48,7 +68,11 @@ functions:
           statusCode: 201
           request:
             template:
-              application/json: '{ "id": "$input.params(''id'')", "body": "$util.escapeJavaScript($input.json(''$''))", "registry": "https://registry.npmjs.org/" }'
+              application/json: >
+                {
+                  "id": "$input.params('id')",
+                  "body": "$util.escapeJavaScript($input.json('$'))"
+                }
 
 resources:
   Resources:

--- a/src/authorizer/index.js
+++ b/src/authorizer/index.js
@@ -1,0 +1,62 @@
+import GitHub from 'github'
+import Promise from 'bluebird'
+import env from '../../env.js'
+
+const generatePolicy = (principalId, effect, resource) => {
+  const authResponse = {}
+  authResponse.principalId = principalId
+
+  if (effect && resource) {
+    const policyDocument = {}
+    policyDocument.Version = '2012-10-17'
+    policyDocument.Statement = []
+
+    const statementOne = {}
+    statementOne.Action = 'execute-api:Invoke'
+    statementOne.Effect = effect
+    statementOne.Resource = resource
+    policyDocument.Statement[0] = statementOne
+    authResponse.policyDocument = policyDocument
+  }
+
+  return authResponse
+}
+
+export const handler = async ({ authorizationToken }, context) => {
+  const { github: githubConfig } = env(context)
+
+  const tokenParts = authorizationToken.split('Bearer ')
+
+  if (tokenParts.length <= 1) {
+    return context.succeed(generatePolicy(authorizationToken, 'Deny', '*'))
+  }
+
+  const token = tokenParts[1]
+
+  const github = new GitHub({
+    Promise,
+    protocol: githubConfig.endpoint.protocol,
+    host: githubConfig.endpoint.host,
+    pathPrefix: githubConfig.endpoint.pathPrefix
+  })
+
+  github.authenticate({
+    type: 'basic',
+    username: githubConfig.client_id,
+    password: githubConfig.secret
+  })
+
+  try {
+    await github.authorization.check({
+      client_id: githubConfig.client_id,
+      access_token: token
+    })
+    return context.succeed(
+      generatePolicy(token, 'Allow', '*')
+    )
+  } catch (error) {
+    return context.succeed(
+      generatePolicy(token, 'Deny', '*')
+    )
+  }
+}

--- a/src/package/get/index.js
+++ b/src/package/get/index.js
@@ -33,15 +33,13 @@ const getFromNPM = async ({ id, registry }) => {
   }
 }
 
-export const handler = async (event, context, callback) => {
-  return callback(null, await (async () => {
-    try {
-      return await getLocally(event)
-    } catch (error) {
-      if (error.code === 'NoSuchKey') {
-        return await getFromNPM(event)
-      }
-      return responses.error(error)
+export const handler = async (event, context) => {
+  try {
+    return context.succeed(await getLocally(event))
+  } catch (error) {
+    if (error.code === 'NoSuchKey') {
+      return context.succeed(await getFromNPM(event))
     }
-  })())
+    return context.fail(error)
+  }
 }

--- a/src/user/put/index.js
+++ b/src/user/put/index.js
@@ -1,45 +1,72 @@
-import AWS from 'aws-sdk'
-import fetch from 'node-fetch'
+import GitHub from 'github'
+import Promise from 'bluebird'
+import env from '../../../env.js'
 
-const loginToNPM = async ({ id, registry, body }) => {
+const loginToGithub = async ({ id, body }, config) => {
   const {
     name,
-    password,
-    email
+    password
   } = JSON.parse(body)
 
-  const reqBody = {
-    _id: id,
-    name,
-    password,
-    email,
-    type: "user",
-    roles: [],
-    date: new Date()
-  }
+  const nameParts = name.split('.')
+  const username = nameParts[0]
+  const otp = nameParts.length > 1 ? nameParts[nameParts.length - 1] : ''
 
-  const req = {
-    method: 'PUT',
+  const github = new GitHub({
+    Promise,
+    protocol: config.github.endpoint.protocol,
+    host: config.github.endpoint.host,
+    pathPrefix: config.github.endpoint.pathPrefix
+  })
+
+  github.authenticate({
+    type: 'basic',
+    username,
+    password
+  })
+
+  let auth = await github.authorization.getOrCreateAuthorizationForApp({
+    scopes: ['user'],
+    client_id: config.github.client_id,
+    client_secret: config.github.secret,
+    note: 'yith private npm registry',
     headers: {
-      'content-type': 'application/json'
-    },
-    body: JSON.stringify(reqBody)
+      'X-GitHub-OTP': otp
+    }
+  })
+
+  if (!auth.token.length) {
+    await github.authorization.delete({
+      id: auth.id,
+      headers: {
+        'X-GitHub-OTP': otp
+      }
+    })
+
+    auth = await github.authorization.create({
+      scopes: ['user'],
+      client_id: config.github.client_id,
+      client_secret: config.github.secret,
+      note: 'yith private npm registry',
+      headers: {
+        'X-GitHub-OTP': otp
+      }
+    })
   }
 
-  try {
-    const response = await fetch(`${registry}-/user/${id}`, req)
-    return await response.json()
-  } catch (error) {
-    return { error: error.message }
-  }
+  return auth
 }
 
-export const handler = async (event, context, callback) => {
-  return callback(null, await (async () => {
-    try {
-      return await loginToNPM(event)
-    } catch (error) {
-      return { error: error.message }
-    }
-  })())
+export const handler = async (event, context) => {
+  const config = env(context)
+
+  try {
+    const { token } = await loginToGithub(event, config)
+    return context.succeed({
+      ok: true,
+      token
+    })
+  } catch (error) {
+    return context.fail(new Error('[401] Unauthorized'))
+  }
 }


### PR DESCRIPTION
## Overview
This work replaces npm authentication to use GitHub / GitHub Enterprise as this is much more relevant especially in larger companies in which they require LDAP integration.  It additionally supports 2FA (if enabled).

### Using github.com
* Create developer application within your github.com account
* Create a file called `.config-dev` and replace relevant property values:
``` js
module.exports = {
  registry: 'https://registry.npmjs.org/',
  github: {
    endpoint: {
      protocol: 'https',
      host: 'api.github.com',
      pathPrefix: '/'
    },
    client_id: 'APP_CLIENT_ID',
    secret: 'APP_SECRET'
  }
}
```
* `npm run build`
